### PR TITLE
Restore BPMs in white cards

### DIFF
--- a/webroot/data/white_cards.yml
+++ b/webroot/data/white_cards.yml
@@ -849,10 +849,10 @@ BT:
   - Monoshy and wobniaR.
   - Moonbutt.
   - Multi-Track Drifting.
-  - "."
+  - "[](/takei)."
   - Princessy.
   - Racist Barn.
-  - "."
+  - "[](/bpdrunk)."
   - RANBO SHAD.
   - Request all the things!
   - SCOOTALUBE.


### PR DESCRIPTION
Takei and drunk Berry Punch went missing. Put 'em back.

Partial revert of 5578a874e1489b345932689d30c16c8e7b5865fa
