### PR TITLE
Avoid extra draws for afk/czar players; closes #27

### DIFF
--- a/webroot/game.py
+++ b/webroot/game.py
@@ -270,13 +270,14 @@ class Game(object):
             extra_cards = 0
 
         for i, user in enumerate(self.users):
-            num_cards = len(user.hand)
-            cards = self._get_white_cards(10 + extra_cards - num_cards)
-            if len(cards) > 0:
-                user.hand.extend(cards)
-                self._publish("send_hand",
-                    {"white_cards": user.hand},
-                    eligible=[user.session])
+            if not user.czar and not user.afk:
+                num_cards = len(user.hand)
+                cards = self._get_white_cards(10 + extra_cards - num_cards)
+                if len(cards) > 0:
+                    user.hand.extend(cards)
+                    self._publish("send_hand",
+                        {"white_cards": user.hand},
+                        eligible=[user.session])
         self._start_round_timer(self._state.round_length)
 
     def _set_next_czar(self):

--- a/webroot/static/css/cah.css
+++ b/webroot/static/css/cah.css
@@ -168,6 +168,8 @@ html, body {
 
 .hand_container {
     position: relative;
+	min-width: 50vw;
+	min-height: 20vh;
 }
 
 .afk {


### PR DESCRIPTION
Since this defers the initial hand draw for the first czar, add some CSS
to make their inital display comprehensible even with an empty hand.
