### PR TITLE
Use Autobahn as a Resource; closes #41

### DIFF
--- a/src/caewebsockets.py
+++ b/src/caewebsockets.py
@@ -2,11 +2,7 @@ import os
 import sys
 
 import yaml
-from twisted.application import service
-from twisted.internet import reactor
-from twisted.python import log
 from autobahn.wamp import WampServerFactory, WampServerProtocol, exportRpc
-from autobahn.websocket import listenWS
 
 from game import Game
 from roomsmanager import rooms, get_smallest_game_id, create_new_game, get_or_create_room
@@ -15,7 +11,7 @@ with open("config.yml") as f:
     config = yaml.load(f)
     config['admin_password'] = os.getenv('CAH_ADMIN_PASS', config['admin_password'])
 
-class CahWampServer(WampServerProtocol):
+class CahWampServerProtocol(WampServerProtocol):
     def __init__(self):
         self._username = ""
         self._game_id = -1
@@ -83,7 +79,7 @@ class CahWampServer(WampServerProtocol):
         elif self._game:
             self._game.remove_user(self._username)
         self._game_id = game_id
-        prefix = 'http://{}:{}/{}{}#'
+        prefix = 'http://{}:{}/ws/{}{}#'
         self.registerForRpc(self, prefix.format(
             config['server_domain'],
             config['server_port'],
@@ -102,7 +98,7 @@ class CahWampServer(WampServerProtocol):
         return game_id
 
     def onSessionOpen(self):
-        self.registerProcedureForRpc("http://{server_domain}:{server_port}/#join_game".format(**config),
+        self.registerProcedureForRpc("http://{server_domain}:{server_port}/ws/#join_game".format(**config),
             self.join_game)
 
     def connectionLost(self, reason):
@@ -113,15 +109,11 @@ class CahWampServer(WampServerProtocol):
         except:
             pass
 
-class CahWampService(service.Service):
-    def __init__(self, server, port, topicuri, factory):
-        self.server = server
-        self.port = port
-        self.topicuri = topicuri
-        self.factory = factory
-    
-    def startService(self):
-        Game.register_cah_wamp_client(self.factory)
-        Game.set_publish_uri(self.topicuri)
-        listenWS(self.factory)
-        log.msg('Started CAH Websocket server')
+class CahServerFactory(WampServerFactory):
+    protocol = CahWampServerProtocol
+
+    def __init__(self, url, publish_uri, **kwargs):
+        WampServerFactory.__init__(self, url, **kwargs)
+        Game.register_cah_wamp_client(self)
+        Game.set_publish_uri(publish_uri)
+        self.startFactory() #hack!

--- a/src/cah.tac
+++ b/src/cah.tac
@@ -3,11 +3,11 @@ import os
 import yaml
 
 from twisted.application import internet, service
-from twisted.web import static, server, resource
-from autobahn.wamp import WampServerFactory
+from twisted.web import static, server
+from autobahn.resource import WebSocketResource
 
 import pystache
-from caewebsockets import CahWampServer, CahWampService
+from caewebsockets import CahServerFactory
 
 WEBROOT_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "www")
 
@@ -15,21 +15,9 @@ with open("config.yml") as f:
     config = yaml.load(f)
     config['admin_password'] = os.getenv('CAH_ADMIN_PASS', config['admin_password'])
 
-cahService = service.MultiService()
-
-## Set up the websocket server
-serverURI = "ws://{websocket_domain}:{websocket_port}".format(**config)
-cahWampFactory = WampServerFactory(serverURI, debug=False, debugWamp=True)
-cahWampFactory.protocol = CahWampServer
-CahWampService(
-    config['websocket_domain'],
-    config['websocket_port'],
-    "{server_domain}:{server_port}".format(**config),
-    cahWampFactory,
-    ).setServiceParent(cahService)
-
 ## Set up the web server
 fileResource = static.File(os.path.join(WEBROOT_DIR))
+fileResource.indexNames=['index.mustache']
 
 # This is the ugly bit--we need to construct a resource tree to get our templated .js in here
 jsResource = static.File(os.path.join(WEBROOT_DIR, "js"))
@@ -40,11 +28,25 @@ with open(os.path.join(WEBROOT_DIR, "js", "init.mustache")) as f:
         )
 fileResource.putChild('js', jsResource)
 
-fileResource.indexNames=['index.mustache']
+# Serve up websockets
+serverURI = "ws://{websocket_domain}:{websocket_port}".format(**config)
+cahWampFactory = CahServerFactory(
+    serverURI,
+    "{server_domain}:{server_port}".format(**config),
+    debug=False,
+    debugWamp=True,
+    debugCodePaths=False,
+    debugApp=False
+)
+wsResource = WebSocketResource(cahWampFactory)
+fileResource.putChild('ws', wsResource)
 
 fileServer = server.Site(fileResource)
-internet.TCPServer(config['server_port'], fileServer).setServiceParent(cahService)
 
 ## Define the application
 application = service.Application("CAH")
-cahService.setServiceParent(application)
+internet.TCPServer(
+    int(config['server_proxy_port']),
+    fileServer,
+    interface=config['server_interface']
+).setServiceParent(application)

--- a/src/config.yml
+++ b/src/config.yml
@@ -3,8 +3,10 @@ admin_password: asdf
 
 # Websocket configuration
 websocket_domain: localhost
-websocket_port: 9000
+websocket_port: 8765
 
 # Web server configuration
 server_domain: localhost
 server_port: 8765
+server_proxy_port: 8765
+server_interface: ""

--- a/src/game.py
+++ b/src/game.py
@@ -11,7 +11,7 @@ from utils import roundrobin
 
 ABS_PATH = os.path.dirname(os.path.realpath(__file__))
 
-publish = "http://{}/{}#{}"
+publish = "http://{}/ws/{}#{}"
 
 class Game(object):
     def __init__(self, game_id, empty_game_callback):

--- a/src/www/js/init.mustache
+++ b/src/www/js/init.mustache
@@ -2,6 +2,6 @@ var cah = {
     debug:true,
     CHATLIST: [],
     subscribed_topics: [],
-    wamp_prefix: "http://{{ server_domain }}:{{ server_port }}/",
-    wsuri: "ws://{{ websocket_domain }}:{{ websocket_port }}"
+    wamp_prefix: "http://{{ server_domain }}:{{ server_port }}/ws/",
+    wsuri: "ws://{{ websocket_domain }}:{{ websocket_port }}/ws"
 };


### PR DESCRIPTION
This runs Autobahn as a Resource under TwistedWeb, instead of as a
separate Twisted Service, which allows all communication to happen over
good ol' Port 80, thus avoiding portblocking by most firewalls.

Cherry-picked off the OpenShift deployment work.
